### PR TITLE
Fix typo in URL so API endpoints are actually queried now

### DIFF
--- a/frontend/index.py
+++ b/frontend/index.py
@@ -14,7 +14,7 @@ if deployment == "LOCAL":
 elif deployment == "DOCKER_LOCAL":
     URL = "http://localhost:8080/"
 elif deployment == "DOCKER_GCP":
-    URL = "https://apiv2-fjs6hewsza-ew.a.run.app"
+    URL = "https://apiv2-fjs6hewsza-ew.a.run.app/"
 
 # Setup page
 st.set_page_config(


### PR DESCRIPTION
Fix typo in the URL in index.py